### PR TITLE
Utiliza listas con FontAwesome icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,10 +60,12 @@ main img {
   margin-bottom: 2rem;
 }
 
-i {
-  padding-right: 0.5rem;
-  font-size: 2em;
+i.fa-li {
   color: #db0076;
+}
+
+ul li {
+  margin-bottom: 0.7rem;
 }
 
 .margin {
@@ -157,10 +159,6 @@ header p {
 }
 
 /* ------------------------------------------------------- */
-
-.texto-consejos {
-  padding-left: 2rem;
-}
 
 footer {
   background-color: #231f20;

--- a/css/style.css
+++ b/css/style.css
@@ -73,12 +73,6 @@ ul li {
   margin-right: 1.5rem;
 }
 
-@media (max-width: 600px) {
-  i {
-    font-size: 1.5rem;
-  }
-}
-
 main img {
   width: 100%;
   max-width: 50rem;
@@ -167,4 +161,11 @@ footer {
   padding-bottom: 1rem;
   padding-top: 1rem;
   margin-top: 6rem;
+}
+
+/* ------------------------------------------------------- */
+
+/* Remove left margin from list items that uses Bootstrap cols */
+ul.fa-ul > li.col-lg-6 {
+  padding-left: 0;
 }

--- a/index.html
+++ b/index.html
@@ -209,39 +209,39 @@
       <!-- Consejos de impresión -->
       <section id="consejos">
         <h2>CONSEJOS DE IMPRESIÓN</h2>
-        <div class="texto-consejos">
-          <p>
-            <i class="fas fa-desktop"></i>
+        <ul class="fa-ul">
+          <li>
+            <i class="fa-li fas fa-desktop"></i>
             Antes de realizar un montaje
             <strong>consulta las medidas del pliego </strong>
             a imprimir.
-          </p>
-          <p>
-            <i class="fas fa-palette"></i>
+          </li>
+          <li>
+            <i class="fa-li fas fa-palette"></i>
             Verifica que los colores sean <strong>CMYK</strong>.
-          </p>
-          <p>
-            <i class="fas fa-sticky-note"></i>
+          </li>
+          <li>
+            <i class="fa-li fas fa-sticky-note"></i>
             <strong>Deja margenes</strong> de seguridad de 6mm.
-          </p>
-          <p>
-            <i class="fab fa-fonticons"></i>
+          </li>
+          <li>
+            <i class="fa-li fab fa-fonticons"></i>
             Convertir las tipografías en <strong>"curvas"</strong>.
-          </p>
-          <p>
-            <i class="fas fa-image"></i>
+          </li>
+          <li>
+            <i class="fa-li fas fa-image"></i>
             Utiliza una resolución de <strong>300 dpi</strong>.
-          </p>
-          <p>
-            <i class="fas fa-file-pdf"></i>
+          </li>
+          <li>
+            <i class="fa-li fas fa-file-pdf"></i>
             Envia el archivo en formato <strong>PDF</strong>.
-          </p>
-          <p>
-            <i class="fas fa-search"></i>
+          </li>
+          <li>
+            <i class="fa-li fas fa-search"></i>
             <strong>Informa los detalles</strong> a tener en cuenta para la
             impresión.
-          </p>
-        </div>
+          </li>
+        </ul>
       </section>
     </main>
 

--- a/index.html
+++ b/index.html
@@ -163,47 +163,43 @@
         <!-- Contactos -->
         <h3>Contactos</h3>
         <p class="margin">
-          <strong>Horatio de atención:</strong> Lunes a viernes de 8:00hs a
+          <strong>Horario de atención:</strong> Lunes a viernes de 8:00hs a
           16:00hs.
         </p>
-        <div class="row justify-content-around">
-          <div class="col-lg-3">
-            <p>
-              <i class="fas fa-phone-square-alt"></i>
-              0341 - 4635206
-            </p>
-            <p>
-              <i class="fab fa-whatsapp-square"></i>
-              <a href="https://api.whatsapp.com/send?phone=543416028904"
-                >341 - 6028904</a
-              >
-            </p>
-          </div>
-          <div class="col-lg-6">
-            <p>
-              <i class="fas fa-envelope-square"></i>
-              <a href="mailto:cromograficaimpresiones@gmail.com"
-                >cromograficaimpresiones@gmail.com</a
-              >
-            </p>
-            <p>
-              <i class="fas fa-map-marked-alt"></i>
-              Paraguay 4373, Rosario, Santa Fe, Argentina
-            </p>
-          </div>
-          <div class="col-lg-1">
-            <p>
-              <a href="https://www.instagram.com/cromograficaimpresiones/">
-                <i class="fab fa-instagram-square"></i>
-              </a>
-            </p>
-            <p>
-              <a href="https://es-la.facebook.com/CromoGraficaImpresiones/">
-                <i class="fab fa-facebook-square"></i>
-              </a>
-            </p>
-          </div>
-        </div>
+        <ul class="list-unstyled row fa-ul">
+          <li class="col-lg-6">
+            <i class="fa-li fas fa-phone-square-alt"></i>
+            0341-4635206
+          </li>
+          <li class="col-lg-6">
+            <i class="fa-li fab fa-whatsapp-square"></i>
+            <a href="https://api.whatsapp.com/send?phone=543416028904"
+              >341-6028904</a
+            >
+          </li>
+          <li class="col-lg-6">
+            <i class="fa-li fas fa-envelope-square"></i>
+            <a href="mailto:cromograficaimpresiones@gmail.com"
+              >cromograficaimpresiones@gmail.com</a
+            >
+          </li>
+          <li class="col-lg-6">
+            <i class="fa-li fas fa-map-marked-alt"></i>
+            Paraguay 4373, Rosario, Santa Fe, Argentina
+          </li>
+          <li class="col-lg-6">
+            <i class="fa-li fab fa-instagram-square"></i>
+            <a href="https://www.instagram.com/cromograficaimpresiones/">
+              @cromograficaimpresiones
+            </a>
+          </li>
+          <li class="col-lg-6">
+            <i class="fa-li fab fa-facebook-square"></i>
+            <a href="https://es-la.facebook.com/CromoGraficaImpresiones/">
+              CromoGraficaImpresiones
+            </a>
+          </li>
+        </ul>
       </section>
 
       <!-- Consejos de impresión -->


### PR DESCRIPTION
Transforma consejos de impresion en una lista con las clases `fa-ul` y `fa-li` para introducir los iconos de FontAwesome.
Transforma contactos en lista usando Boostrap para columnas.
Pequeñas modificaciones al CSS: quita el padding izquierdo de los `li.col-lg-6` hijos de un `ul.fa-ul`.
